### PR TITLE
Display application version in title bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "editora",
-  "version": "0.1.0",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "editora",
-      "version": "0.1.0",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editora",
-  "version": "0.1.0",
+  "version": "0.0.2",
   "description": "Desktop CMS for Astro-based websites",
   "main": ".vite/build/index.js",
   "author": "Editora",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -120,6 +120,8 @@ const registerAllHandlers = () => {
   ipcMain.handle("shell:show-item-in-folder", (_event, filePath: string) => {
     shell.showItemInFolder(filePath);
   });
+
+  ipcMain.handle("app:get-version", () => app.getVersion());
 };
 
 app.whenReady().then(() => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -102,6 +102,9 @@ const api = {
   // Shell
   showItemInFolder: (filePath: string) =>
     ipcRenderer.invoke("shell:show-item-in-folder", filePath),
+
+  // App
+  getVersion: () => ipcRenderer.invoke("app:get-version"),
 };
 
 contextBridge.exposeInMainWorld("editora", api);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,12 @@ import TerminalPanel from "./components/layout/TerminalPanel";
 import ShortcutsPanel from "./components/layout/ShortcutsPanel";
 
 function TitleBar() {
+  const [version, setVersion] = useState<string>("");
+
+  useEffect(() => {
+    window.editora.getVersion().then(setVersion);
+  }, []);
+
   return (
     <div
       className="h-9 flex-shrink-0 flex items-center bg-editor-surface border-b select-none"
@@ -18,7 +24,9 @@ function TitleBar() {
     >
       {/* Spacer for macOS traffic lights */}
       <div className="w-[78px] flex-shrink-0" />
-      <span className="text-xs text-editor-muted font-medium">Editora</span>
+      <span className="text-xs text-editor-muted font-medium">
+        Editora{version ? ` v${version}` : ""}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR adds the application version to the title bar, displaying it next to the "Editora" application name.

## Key Changes
- **App.tsx**: Modified the `TitleBar` component to fetch and display the application version
  - Added `useState` and `useEffect` hooks to retrieve the version from the main process
  - Updated the title bar text to show "Editora v{version}" when version is available
- **src/preload/index.ts**: Exposed a new `getVersion()` IPC method to the renderer process
- **src/main/index.ts**: Registered an IPC handler for `app:get-version` that returns the application version from Electron's `app.getVersion()`
- **package.json**: Updated version from `0.1.0` to `0.0.2`

## Implementation Details
- The version is fetched asynchronously when the `TitleBar` component mounts
- The IPC communication follows the existing pattern used for other app handlers
- The version display gracefully handles the case where the version hasn't loaded yet by showing just "Editora" until the version is available

https://claude.ai/code/session_013dBxnKwKV7LCb7T3t5ppz6